### PR TITLE
Allow HTTPS Connections

### DIFF
--- a/app/utils/host.js
+++ b/app/utils/host.js
@@ -33,6 +33,10 @@ function ws_base_url() {
   */
   let base = `ws://${window.location.host}`;
 
+  if (document.location.protocol == 'https:') {
+    base = `wss://${window.location.host}`;
+  }
+
   if (ENV.APP.WS_HOST) {
     // user can override BACKEND HOST by providing
     // ENV.APP.HOST value


### PR DESCRIPTION
When using HTTPS we need to use WSS to create a secure websocket.